### PR TITLE
Modify the location of RayExecutor import

### DIFF
--- a/data_juicer/core/__init__.py
+++ b/data_juicer/core/__init__.py
@@ -1,6 +1,5 @@
 from .analyser import Analyser
 from .data import NestedDataset
 from .executor import Executor
-from .ray_executor import RayExecutor
 from .exporter import Exporter
 from .tracer import Tracer

--- a/tools/process_data.py
+++ b/tools/process_data.py
@@ -1,7 +1,7 @@
 from loguru import logger
 
 from data_juicer.config import init_configs
-from data_juicer.core import Executor, RayExecutor
+from data_juicer.core import Executor
 
 
 @logger.catch
@@ -10,6 +10,7 @@ def main():
     if cfg.executor_type == 'default':
         executor = Executor(cfg)
     elif cfg.executor_type == 'ray':
+        from data_juicer.core.ray_executor import RayExecutor
         executor = RayExecutor(cfg)
     executor.run()
 


### PR DESCRIPTION
When using DJ to process large-scale data, there will be a ray bug.  
https://github.com/ray-project/ray/issues/17745
Currently, it is adjusted to import ray only when using it.