### PR TITLE
Better Analyzer support for stats of multimodal OPs & other minor enhancements

### DIFF
--- a/data_juicer/analysis/column_wise_analysis.py
+++ b/data_juicer/analysis/column_wise_analysis.py
@@ -112,7 +112,8 @@ class ColumnWiseAnalysis:
             fig = plt.figure(figsize=(rec_width, rec_height),
                              layout='constrained')
             subfigs = fig.subfigures(rec_row, rec_col, wspace=0.01)
-        for i, column_name in tqdm(enumerate(columns), desc='Column'):
+        for i, column_name in tqdm(enumerate(columns.to_list()),
+                                   desc='Column'):
             data = self.stats[column_name]
             # explode data to flatten inner list
             data = data.explode().infer_objects()

--- a/data_juicer/analysis/column_wise_analysis.py
+++ b/data_juicer/analysis/column_wise_analysis.py
@@ -3,6 +3,7 @@ import os
 
 import matplotlib.pyplot as plt
 import pandas as pd
+from tqdm import tqdm
 
 from data_juicer.utils.constant import Fields
 
@@ -111,8 +112,10 @@ class ColumnWiseAnalysis:
             fig = plt.figure(figsize=(rec_width, rec_height),
                              layout='constrained')
             subfigs = fig.subfigures(rec_row, rec_col, wspace=0.01)
-        for i, column_name in enumerate(columns):
+        for i, column_name in tqdm(enumerate(columns), desc='Column'):
             data = self.stats[column_name]
+            # explode data to flatten inner list
+            data = data.explode().infer_objects()
             grid = grid_indexes[i]
             if self.save_stats_in_one_file:
                 if rec_col == 1:
@@ -128,7 +131,8 @@ class ColumnWiseAnalysis:
 
             # numeric or string via nan. Apply different plot method for them.
             if pd.isna(self.overall_result[column_name].get('top')):
-                # numeric -- draw histogram and box plot for this stat
+                # numeric or numeric list -- draw histogram and box plot for
+                # this stat
                 percentiles = self.overall_result[column_name] \
                     if show_percentiles else None
 
@@ -152,7 +156,8 @@ class ColumnWiseAnalysis:
                                            f'{column_name}-box.png'),
                               percentiles=percentiles)
             else:
-                # object (string) -- only draw histogram for this stat
+                # object (string) or string list -- only draw histogram for
+                # this stat
                 if self.save_stats_in_one_file:
                     axes = subfig.subplots(1, 1)
                 else:

--- a/data_juicer/analysis/column_wise_analysis.py
+++ b/data_juicer/analysis/column_wise_analysis.py
@@ -112,8 +112,8 @@ class ColumnWiseAnalysis:
             fig = plt.figure(figsize=(rec_width, rec_height),
                              layout='constrained')
             subfigs = fig.subfigures(rec_row, rec_col, wspace=0.01)
-        for i, column_name in tqdm(enumerate(columns.to_list()),
-                                   desc='Column'):
+        for i, column_name in enumerate(tqdm(columns.to_list(),
+                                             desc='Column')):
             data = self.stats[column_name]
             # explode data to flatten inner list
             data = data.explode().infer_objects()

--- a/data_juicer/analysis/overall_analysis.py
+++ b/data_juicer/analysis/overall_analysis.py
@@ -1,8 +1,16 @@
 import os
+from multiprocessing import Pool
 
 import pandas as pd
+from loguru import logger
+from tqdm import tqdm
 
 from data_juicer.utils.constant import Fields
+
+
+def _single_column_analysis(col, *args, **kwargs):
+    col_overall = col.describe(*args, **kwargs)
+    return col_overall
 
 
 class OverallAnalysis:
@@ -23,18 +31,60 @@ class OverallAnalysis:
 
         # default percentiles to analyse
         self.default_percentiles = [0.25, 0.5, 0.75]
+        # supported dtypes of column to be analysed
+        # Notice: there won't be mixed types in a column because the stats is
+        # obtained from Dataset, which doesn't allow mixed types.
+        # Notice: for now, stats can only be:
+        # {numbers, string, list of one of before}
+        self.supported_object_types = {str, list}
 
-    def analyse(self, percentiles=[]):
+    def refine_single_column(self, col):
+        if col.dtype != 'object':
+            # not an object, return directly
+            return col
+        # if the type of this column is object, we can decide the actual type
+        # according to the first element.
+        first = col[0]
+        if type(first) not in self.supported_object_types:
+            logger.warning(f'There is a column of stats with type '
+                           f'[{type(first)}], which is not supported to be '
+                           f'analysed for now.')
+            return None
+        if type(first) is str:
+            # describe(include = 'all') can analyze the string type
+            return col
+        elif type(first) is list:
+            # flatten and infer the type
+            col = col.explode().infer_objects()
+            return col
+
+    def analyse(self, percentiles=[], num_proc=1):
         """
         Apply overall analysis on the whole dataset based on the describe
         method of pandas.
 
         :param percentiles: percentiles to analyse
+        :param num_proc: number of processes to analyse the dataset
         :return: the overall analysis result.
         """
         # merge default and customized percentiles and get overall information
         percentiles = list(set(percentiles + self.default_percentiles))
-        overall = self.stats.describe(percentiles=percentiles, include='all')
+
+        results = []
+        pool = Pool(num_proc)
+        for col_name in self.stats.columns:
+            this_col = self.refine_single_column(self.stats[col_name])
+            res = pool.apply_async(_single_column_analysis,
+                                   kwds={
+                                       'col': this_col,
+                                       'percentiles': percentiles,
+                                       'include': 'all',
+                                   })
+            results.append(res)
+        pool.close()
+        pool.join()
+        result_cols = [res.get() for res in tqdm(results)]
+        overall = pd.DataFrame(result_cols).T
 
         # export to result report file
         overall.to_csv(os.path.join(self.output_path, 'overall.csv'))

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -89,6 +89,20 @@ def init_configs(args=None):
         'due to the IO blocking, especially for very large datasets. '
         'When this happens, False is a better choice, although it takes '
         'more time.')
+    parser.add_argument(
+        '--keep_stats_in_res_ds',
+        type=bool,
+        default=False,
+        help='Whether to keep the computed stats in the result dataset. If '
+        'it\'s False, the intermediate fields to store the stats '
+        'computed by Filters will be removed. Default: False.')
+    parser.add_argument(
+        '--keep_hashes_in_res_ds',
+        type=bool,
+        default=False,
+        help='Whether to keep the computed hashes in the result dataset. If '
+        'it\'s False, the intermediate fields to store the hashes '
+        'computed by Deduplicators will be removed. Default: False.')
     parser.add_argument('--np',
                         type=PositiveInt,
                         default=4,

--- a/data_juicer/core/analyser.py
+++ b/data_juicer/core/analyser.py
@@ -9,6 +9,7 @@ from data_juicer.ops import Filter, load_ops
 from data_juicer.utils import cache_utils
 from data_juicer.utils.constant import Fields
 
+from .data import add_same_content_to_new_column
 from .exporter import Exporter
 
 
@@ -87,12 +88,14 @@ class Analyser:
             op_name = list(op_cfg.keys())[0]
             if isinstance(op, Filter):
                 if Fields.stats not in dataset.features:
-                    # TODO:
-                    # this is a temp solution,
                     # only add stats when calling filter op
-                    dataset = dataset.add_column(name=Fields.stats,
-                                                 column=[{}] *
-                                                 dataset.num_rows)
+                    dataset = dataset.map(add_same_content_to_new_column,
+                                          fn_kwargs={
+                                              'new_column_name': Fields.stats,
+                                              'initial_value': {}
+                                          },
+                                          num_proc=self.cfg.np,
+                                          desc='Adding new column for stats')
                 dataset = dataset.map(op.compute_stats,
                                       num_proc=self.cfg.np,
                                       desc=op_name + '_compute_stats')

--- a/data_juicer/core/analyser.py
+++ b/data_juicer/core/analyser.py
@@ -120,7 +120,7 @@ class Analyser:
 
         logger.info('Applying overall analysis on stats...')
         overall_analysis = OverallAnalysis(dataset, self.analysis_path)
-        self.overall_result = overall_analysis.analyse()
+        self.overall_result = overall_analysis.analyse(num_proc=self.cfg.np)
 
         logger.info('Applying column-wise analysis on stats...')
         column_wise_analysis = ColumnWiseAnalysis(

--- a/data_juicer/core/analyser.py
+++ b/data_juicer/core/analyser.py
@@ -102,11 +102,18 @@ class Analyser:
                            'the process list in configs.')
             return dataset
 
-        # 3. analysis and output result to the export path
-        # 3.1. Only consider fields in Fields.stats
-        # 3.2. For string fields, only consider its histogram
-        # 3.3. For numeric fields, consider its histogram and box
-        # 3.4. Otherwise, DO NOT analyse
+        # 3. data export
+        logger.info('Exporting dataset to disk...')
+        self.exporter.export(dataset)
+        if self.cfg.use_cache and self.cfg.cache_compress:
+            from data_juicer.utils.compress import compress
+            compress(dataset)
+
+        # 4. analysis and output result to the export path
+        # 4.1. Only consider fields in Fields.stats
+        # 4.2. For string fields, only consider its histogram
+        # 4.3. For numeric fields, consider its histogram and box
+        # 4.4. Otherwise, DO NOT analyse
 
         logger.info('Applying overall analysis on stats...')
         overall_analysis = OverallAnalysis(dataset, self.analysis_path)
@@ -120,10 +127,4 @@ class Analyser:
             save_stats_in_one_file=self.cfg.save_stats_in_one_file)
         column_wise_analysis.analyse()
 
-        # 4. data export
-        logger.info('Exporting dataset to disk...')
-        self.exporter.export(dataset)
-        if self.cfg.use_cache and self.cfg.cache_compress:
-            from data_juicer.utils.compress import compress
-            compress(dataset)
         return dataset

--- a/data_juicer/core/data.py
+++ b/data_juicer/core/data.py
@@ -317,3 +317,17 @@ def nested_query(root_obj: Union[NestedDatasetDict, NestedDataset,
                 return None
 
     return None
+
+
+def add_same_content_to_new_column(sample,
+                                   new_column_name,
+                                   initial_value=None):
+    """
+    A helper function to speed up add_column function. Apply map on this
+    function in parallel instead of using add_column.
+    :param sample: a single sample to add this new column/field.
+    :param new_column_name: the name of this new column/field.
+    :param initial_value: the initial value of this new column/field.
+    """
+    sample[new_column_name] = initial_value
+    return sample

--- a/data_juicer/core/executor.py
+++ b/data_juicer/core/executor.py
@@ -66,9 +66,13 @@ class Executor:
 
         # prepare exporter and check export path suffix
         logger.info('Preparing exporter...')
-        self.exporter = Exporter(self.cfg.export_path,
-                                 self.cfg.export_shard_size,
-                                 self.cfg.export_in_parallel, self.cfg.np)
+        self.exporter = Exporter(
+            self.cfg.export_path,
+            self.cfg.export_shard_size,
+            self.cfg.export_in_parallel,
+            self.cfg.np,
+            keep_stats_in_res_ds=self.cfg.keep_stats_in_res_ds,
+            keep_hashes_in_res_ds=self.cfg.keep_hashes_in_res_ds)
 
         # setup tracer
         self.open_tracer = self.cfg.open_tracer

--- a/data_juicer/core/executor.py
+++ b/data_juicer/core/executor.py
@@ -11,6 +11,7 @@ from data_juicer.utils import cache_utils
 from data_juicer.utils.ckpt_utils import CheckpointManager
 from data_juicer.utils.constant import Fields
 
+from .data import add_same_content_to_new_column
 from .exporter import Exporter
 from .tracer import Tracer
 
@@ -125,12 +126,15 @@ class Executor:
                                                      op.text_key)
                 elif isinstance(op, Filter):
                     if Fields.stats not in dataset.features:
-                        # TODO:
-                        # this is a temp solution,
                         # only add stats when calling filter op
-                        dataset = dataset.add_column(name=Fields.stats,
-                                                     column=[{}] *
-                                                     dataset.num_rows)
+                        dataset = dataset.map(
+                            add_same_content_to_new_column,
+                            fn_kwargs={
+                                'new_column_name': Fields.stats,
+                                'initial_value': {}
+                            },
+                            num_proc=self.cfg.np,
+                            desc='Adding new column for stats')
                         if self.cfg.use_checkpoint:
                             prev = dataset
                     dataset = dataset.map(op.compute_stats,

--- a/data_juicer/format/text_formatter.py
+++ b/data_juicer/format/text_formatter.py
@@ -150,7 +150,7 @@ class TextFormatter(LocalFormatter):
         # whether to add file suffix to datase meta info
         if self.add_suffix:
             logger.info('Add suffix info into dataset...')
-            datasets = add_suffixes(datasets)
+            datasets = add_suffixes(datasets, num_proc)
         else:
             datasets = concatenate_datasets([ds for _, ds in datasets.items()])
         return unify_format(datasets,

--- a/data_juicer/ops/load.py
+++ b/data_juicer/ops/load.py
@@ -17,15 +17,17 @@ def load_ops(process_list, op_fusion=False):
     :return: The op instance list.
     """
     ops = []
+    new_process_list = []
     for process in process_list:
         op_name, args = list(process.items())[0]
         if op_name in UNAVAILABLE_OPERATORS:
             logger.warning(UNAVAILABLE_OPERATORS[op_name].get_warning_msg())
             continue
         ops.append(OPERATORS.modules[op_name](**args))
+        new_process_list.append(process)
 
     # detect filter groups
     if op_fusion:
-        process_list, ops = fuse_operators(process_list, ops)
+        new_process_list, ops = fuse_operators(new_process_list, ops)
 
-    return process_list, ops
+    return new_process_list, ops

--- a/demos/tool_dataset_splitting_by_language/dataset_splitting_by_language.py
+++ b/demos/tool_dataset_splitting_by_language/dataset_splitting_by_language.py
@@ -7,6 +7,7 @@ import fire
 import pandas as pd
 from loguru import logger
 
+from data_juicer.core.data import add_same_content_to_new_column
 from data_juicer.format import load_formatter
 from data_juicer.ops.filter.language_id_score_filter import \
     LanguageIDScoreFilter
@@ -51,11 +52,15 @@ def main(src_dir, target_dir, text_key=None, suffixes=[], num_proc=1):
     op = LanguageIDScoreFilter(text_key=text_key)
 
     if Fields.stats not in dataset.features:
-        # TODO:
-        # this is a temp solution,
         # only add stats when calling filter op
-        dataset = dataset.add_column(name=Fields.stats,
-                                     column=[{}] * dataset.num_rows)
+        dataset = dataset.map(
+            add_same_content_to_new_column,
+            fn_kwargs={
+                'new_column_name': Fields.stats,
+                'initial_value': {}
+            },
+            num_proc=num_proc,
+            desc='Adding new column for stats')
 
     # identify language
     dataset = dataset.map(op.compute_stats, num_proc=num_proc)

--- a/tools/preprocess/dataset_split_by_language.py
+++ b/tools/preprocess/dataset_split_by_language.py
@@ -7,6 +7,7 @@ import fire
 import pandas as pd
 from loguru import logger
 
+from data_juicer.core.data import add_same_content_to_new_column
 from data_juicer.format import load_formatter
 from data_juicer.ops.filter.language_id_score_filter import \
     LanguageIDScoreFilter
@@ -52,11 +53,14 @@ def main(src_dir, target_dir, text_key=None, suffixes=[], num_proc=1):
     op = LanguageIDScoreFilter(text_key=text_key)
 
     if Fields.stats not in dataset.features:
-        # TODO:
-        # this is a temp solution,
         # only add stats when calling filter op
-        dataset = dataset.add_column(name=Fields.stats,
-                                     column=[{}] * dataset.num_rows)
+        dataset = dataset.map(add_same_content_to_new_column,
+                              fn_kwargs={
+                                  'new_column_name': Fields.stats,
+                                  'initial_value': {}
+                              },
+                              num_proc=num_proc,
+                              desc='Adding new column for stats')
 
     # identify language
     dataset = dataset.map(op.compute_stats, num_proc=num_proc)


### PR DESCRIPTION
- Add two arguments `keep_stats/hashes_in_res_ds` to control whether to keep stats (computed by Filters) or hashes (computed by Deduplicators) in the exported result dataset. In default, they are False.
  - From #102 
- Analyzer:
  - Save stats before doing the analysis
  - Support to apply overall analysis in parallel
  - Support to apply overall and column-wise analysis for DataFrame column of `list` type (some stats generated by multimodal OPs)