### PR TITLE
Feature/replace content mapper

### DIFF
--- a/data_juicer/ops/mapper/__init__.py
+++ b/data_juicer/ops/mapper/__init__.py
@@ -7,4 +7,5 @@ from . import (chinese_convert_mapper, clean_copyright_mapper,
                remove_long_words_mapper, remove_non_chinese_character_mapper,
                remove_specific_chars_mapper, remove_table_text_mapper,
                remove_words_with_incorrect_substrings_mapper,
-               sentence_split_mapper, whitespace_normalization_mapper)
+               replace_content_mapper, sentence_split_mapper,
+               whitespace_normalization_mapper)

--- a/data_juicer/ops/mapper/clean_email_mapper.py
+++ b/data_juicer/ops/mapper/clean_email_mapper.py
@@ -21,6 +21,10 @@ class CleanEmailMapper(Mapper):
             self.pattern = r'[A-Za-z0-9.\-+_]+@[a-z0-9.\-+_]+\.[a-z]+'
         else:
             self.pattern = pattern
+            if pattern is not None and len(pattern) > 2:
+                if (pattern.startswith("r'") and pattern.endswith("'")
+                        or pattern.startswith('r"') and pattern.endswith('"')):
+                    self.pattern = pattern[2:-1]
 
         self.repl = repl
 

--- a/data_juicer/ops/mapper/clean_email_mapper.py
+++ b/data_juicer/ops/mapper/clean_email_mapper.py
@@ -21,9 +21,9 @@ class CleanEmailMapper(Mapper):
             self.pattern = r'[A-Za-z0-9.\-+_]+@[a-z0-9.\-+_]+\.[a-z]+'
         else:
             self.pattern = pattern
-            if (len(pattern) > 2
-                    and pattern.startswith("r'") and pattern.endswith("'")
-                    or pattern.startswith('r"') and pattern.endswith('"')):
+            if ((len(pattern) > 2) and
+                (pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"'))):
                 self.pattern = pattern[2:-1]
 
         self.repl = repl

--- a/data_juicer/ops/mapper/clean_email_mapper.py
+++ b/data_juicer/ops/mapper/clean_email_mapper.py
@@ -21,10 +21,10 @@ class CleanEmailMapper(Mapper):
             self.pattern = r'[A-Za-z0-9.\-+_]+@[a-z0-9.\-+_]+\.[a-z]+'
         else:
             self.pattern = pattern
-            if pattern is not None and len(pattern) > 2:
-                if (pattern.startswith("r'") and pattern.endswith("'")
-                        or pattern.startswith('r"') and pattern.endswith('"')):
-                    self.pattern = pattern[2:-1]
+            if (len(pattern) > 2
+                    and pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"')):
+                self.pattern = pattern[2:-1]
 
         self.repl = repl
 

--- a/data_juicer/ops/mapper/clean_ip_mapper.py
+++ b/data_juicer/ops/mapper/clean_ip_mapper.py
@@ -26,10 +26,10 @@ class CleanIpMapper(Mapper):
             self.pattern += r'([\da-fA-F]{1,4}:){7}[\da-fA-F]{1,4}'  # ipv6
         else:
             self.pattern = pattern
-            if pattern is not None and len(pattern) > 2:
-                if (pattern.startswith("r'") and pattern.endswith("'")
-                        or pattern.startswith('r"') and pattern.endswith('"')):
-                    self.pattern = pattern[2:-1]
+            if (len(pattern) > 2
+                    and pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"')):
+                self.pattern = pattern[2:-1]
         self.repl = repl
 
     def process(self, sample):

--- a/data_juicer/ops/mapper/clean_ip_mapper.py
+++ b/data_juicer/ops/mapper/clean_ip_mapper.py
@@ -26,7 +26,10 @@ class CleanIpMapper(Mapper):
             self.pattern += r'([\da-fA-F]{1,4}:){7}[\da-fA-F]{1,4}'  # ipv6
         else:
             self.pattern = pattern
-
+            if pattern is not None and len(pattern) > 2:
+                if (pattern.startswith("r'") and pattern.endswith("'")
+                        or pattern.startswith('r"') and pattern.endswith('"')):
+                    self.pattern = pattern[2:-1]
         self.repl = repl
 
     def process(self, sample):

--- a/data_juicer/ops/mapper/clean_ip_mapper.py
+++ b/data_juicer/ops/mapper/clean_ip_mapper.py
@@ -7,20 +7,27 @@ from ..base_op import OPERATORS, Mapper
 class CleanIpMapper(Mapper):
     """Mapper to clean ipv4 and ipv6 address in text samples."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, pattern: str = None, repl: str = '', *args, **kwargs):
         """
         Initialization method.
 
+        :param pattern: regular expression pattern to search for within text.
+        :param repl: replacement string, default is empty string.
         :param args: extra args
         :param kwargs: extra args
         """
 
         super().__init__(*args, **kwargs)
-        self.pattern = r'(?:(?:1[0-9][0-9]\.)|(?:2[0-4][0-9]\.)|'
-        self.pattern += r'(?:25[0-5]\.)|(?:[1-9][0-9]\.)|(?:[0-9]\.))'
-        self.pattern += r'{3}(?:(?:1[0-9][0-9])|(?:2[0-4][0-9])|'
-        self.pattern += r'(?:25[0-5])|(?:[1-9][0-9])|(?:[0-9]))|'
-        self.pattern += r'([\da-fA-F]{1,4}:){7}[\da-fA-F]{1,4}'  # ipv6
+        if pattern is None:
+            self.pattern = r'(?:(?:1[0-9][0-9]\.)|(?:2[0-4][0-9]\.)|'
+            self.pattern += r'(?:25[0-5]\.)|(?:[1-9][0-9]\.)|(?:[0-9]\.))'
+            self.pattern += r'{3}(?:(?:1[0-9][0-9])|(?:2[0-4][0-9])|'
+            self.pattern += r'(?:25[0-5])|(?:[1-9][0-9])|(?:[0-9]))|'
+            self.pattern += r'([\da-fA-F]{1,4}:){7}[\da-fA-F]{1,4}'  # ipv6
+        else:
+            self.pattern = pattern
+
+        self.repl = repl
 
     def process(self, sample):
 
@@ -28,7 +35,7 @@ class CleanIpMapper(Mapper):
             return sample
 
         sample[self.text_key] = re.sub(pattern=self.pattern,
-                                       repl=r'',
+                                       repl=self.repl,
                                        string=sample[self.text_key],
                                        flags=re.DOTALL)
         return sample

--- a/data_juicer/ops/mapper/clean_ip_mapper.py
+++ b/data_juicer/ops/mapper/clean_ip_mapper.py
@@ -26,9 +26,9 @@ class CleanIpMapper(Mapper):
             self.pattern += r'([\da-fA-F]{1,4}:){7}[\da-fA-F]{1,4}'  # ipv6
         else:
             self.pattern = pattern
-            if (len(pattern) > 2
-                    and pattern.startswith("r'") and pattern.endswith("'")
-                    or pattern.startswith('r"') and pattern.endswith('"')):
+            if ((len(pattern) > 2) and
+                (pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"'))):
                 self.pattern = pattern[2:-1]
         self.repl = repl
 

--- a/data_juicer/ops/mapper/clean_links_mapper.py
+++ b/data_juicer/ops/mapper/clean_links_mapper.py
@@ -10,22 +10,29 @@ from ..base_op import OPERATORS, Mapper
 class CleanLinksMapper(Mapper):
     """Mapper to clean links like http/https/ftp in text samples."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, pattern: str = None, repl: str = '', *args, **kwargs):
         """
         Initialization method.
 
+        :param pattern: regular expression pattern to search for within text.
+        :param repl: replacement string, default is empty string.
         :param args: extra args
         :param kwargs: extra args
         """
         super().__init__(*args, **kwargs)
-        self.pattern = r'(?i)\b('
-        self.pattern += r'(?:[a-z][\w-]+:(?:\/{1,3}|'
-        self.pattern += r'[a-z0-9%])|www\d{0,3}[.]|'
-        self.pattern += r'[a-z0-9.\-]+[.][a-z]{2,4}\/)'
-        self.pattern += r'(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))'
-        self.pattern += r'+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|'
-        self.pattern += r'[^\s`!()\[\]{};:\'\".,<>?«»“”‘’])'
-        self.pattern += r')'
+        if pattern is None:
+            self.pattern = r'(?i)\b('
+            self.pattern += r'(?:[a-z][\w-]+:(?:\/{1,3}|'
+            self.pattern += r'[a-z0-9%])|www\d{0,3}[.]|'
+            self.pattern += r'[a-z0-9.\-]+[.][a-z]{2,4}\/)'
+            self.pattern += r'(?:[^\s()<>]+|\(([^\s()<>]+|'
+            self.pattern += r'(\([^\s()<>]+\)))*\))'
+            self.pattern += r'+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|'
+            self.pattern += r'[^\s`!()\[\]{};:\'\".,<>?«»“”‘’])'
+            self.pattern += r')'
+        else:
+            self.pattern = pattern
+        self.repl = repl
 
     def process(self, sample):
 
@@ -33,7 +40,7 @@ class CleanLinksMapper(Mapper):
             return sample
 
         sample[self.text_key] = re.sub(pattern=self.pattern,
-                                       repl=r'',
+                                       repl=self.repl,
                                        string=sample[self.text_key],
                                        flags=re.DOTALL)
         return sample

--- a/data_juicer/ops/mapper/clean_links_mapper.py
+++ b/data_juicer/ops/mapper/clean_links_mapper.py
@@ -32,6 +32,10 @@ class CleanLinksMapper(Mapper):
             self.pattern += r')'
         else:
             self.pattern = pattern
+            if pattern is not None and len(pattern) > 2:
+                if (pattern.startswith("r'") and pattern.endswith("'")
+                        or pattern.startswith('r"') and pattern.endswith('"')):
+                    self.pattern = pattern[2:-1]
         self.repl = repl
 
     def process(self, sample):

--- a/data_juicer/ops/mapper/clean_links_mapper.py
+++ b/data_juicer/ops/mapper/clean_links_mapper.py
@@ -32,9 +32,9 @@ class CleanLinksMapper(Mapper):
             self.pattern += r')'
         else:
             self.pattern = pattern
-            if (len(pattern) > 2
-                    and pattern.startswith("r'") and pattern.endswith("'")
-                    or pattern.startswith('r"') and pattern.endswith('"')):
+            if ((len(pattern) > 2) and
+                (pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"'))):
                 self.pattern = pattern[2:-1]
         self.repl = repl
 

--- a/data_juicer/ops/mapper/clean_links_mapper.py
+++ b/data_juicer/ops/mapper/clean_links_mapper.py
@@ -32,10 +32,10 @@ class CleanLinksMapper(Mapper):
             self.pattern += r')'
         else:
             self.pattern = pattern
-            if pattern is not None and len(pattern) > 2:
-                if (pattern.startswith("r'") and pattern.endswith("'")
-                        or pattern.startswith('r"') and pattern.endswith('"')):
-                    self.pattern = pattern[2:-1]
+            if (len(pattern) > 2
+                    and pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"')):
+                self.pattern = pattern[2:-1]
         self.repl = repl
 
     def process(self, sample):

--- a/data_juicer/ops/mapper/fix_unicode_mapper.py
+++ b/data_juicer/ops/mapper/fix_unicode_mapper.py
@@ -12,15 +12,29 @@ with AvailabilityChecking(['ftfy'], OP_NAME):
 class FixUnicodeMapper(Mapper):
     """Mapper to fix unicode errors in text samples."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, normalization: str = None, *args, **kwargs):
         """
         Initialization method.
 
+        :param normalization: the specified form of Unicode
+             normalization mode, which can be one of ['NFC',
+            'NFKC', 'NFD', and 'NFKD'], default 'NFC'
         :param args: extra args
         :param kwargs: extra args
         """
         super().__init__(*args, **kwargs)
+        if normalization and len(normalization) > 0:
+            self.normalization = normalization.upper()
+        else:
+            self.normalization = 'NFC'
+
+        if self.normalization.upper() not in ['NFC', 'NFKC', 'NFD', 'NFKD']:
+            raise ValueError(f'Normalization mode [{normalization}] is not '
+                             'supported. Can only be one of '
+                             '["NFC", "NFKC", "NFD", "NFKD"]')
 
     def process(self, sample):
-        sample[self.text_key] = ftfy.fix_text(sample[self.text_key])
+        sample[self.text_key] = ftfy.fix_text(
+                                    sample[self.text_key],
+                                    normalization=self.normalization)
         return sample

--- a/data_juicer/ops/mapper/replace_content_mapper.py
+++ b/data_juicer/ops/mapper/replace_content_mapper.py
@@ -20,10 +20,10 @@ class ReplaceContentMapper(Mapper):
         """
         super().__init__(*args, **kwargs)
         self.pattern = pattern
-        if pattern is not None and len(pattern) > 2:
-            if (pattern.startswith("r'") and pattern.endswith("'")
-                    or pattern.startswith('r"') and pattern.endswith('"')):
-                self.pattern = pattern[2:-1]
+        if ((pattern is not None and len(pattern) > 2) and
+            (pattern.startswith("r'") and pattern.endswith("'") or
+                pattern.startswith('r"') and pattern.endswith('"'))):
+            self.pattern = pattern[2:-1]
         self.repl = repl
 
     def process(self, sample):

--- a/data_juicer/ops/mapper/replace_content_mapper.py
+++ b/data_juicer/ops/mapper/replace_content_mapper.py
@@ -5,11 +5,11 @@ from ..base_op import OPERATORS, Mapper
 
 @OPERATORS.register_module('replace_content_mapper')
 class ReplaceContentMapper(Mapper):
-    """Mapper to replace all content in the text that matches 
-    a specific regular expression pattern with a designated 
+    """Mapper to replace all content in the text that matches
+    a specific regular expression pattern with a designated
     replacement string."""
 
-    def __init__(self, pattern: str=None, repl: str='', *args, **kwargs):
+    def __init__(self, pattern: str = None, repl: str = '', *args, **kwargs):
         """
         Initialization method.
 
@@ -19,11 +19,10 @@ class ReplaceContentMapper(Mapper):
         :param kwargs: extra args
         """
         super().__init__(*args, **kwargs)
-
         self.pattern = pattern
         if pattern is not None and len(pattern) > 0:
-            if (pattern.startswith("r'") and pattern.endswith("'") 
-                    or  pattern.startswith('r"') and pattern.endswith('"')):
+            if (pattern.startswith("r'") and pattern.endswith("'")
+                    or pattern.startswith('r"') and pattern.endswith('"')):
                 self.pattern = pattern[2:-1]
         self.repl = repl
 

--- a/data_juicer/ops/mapper/replace_content_mapper.py
+++ b/data_juicer/ops/mapper/replace_content_mapper.py
@@ -3,11 +3,13 @@ import regex as re
 from ..base_op import OPERATORS, Mapper
 
 
-@OPERATORS.register_module('clean_email_mapper')
-class CleanEmailMapper(Mapper):
-    """Mapper to clean email in text samples."""
+@OPERATORS.register_module('replace_content_mapper')
+class ReplaceContentMapper(Mapper):
+    """Mapper to replace all content in the text that matches 
+    a specific regular expression pattern with a designated 
+    replacement string."""
 
-    def __init__(self, pattern: str = None, repl: str = '', *args, **kwargs):
+    def __init__(self, pattern: str=None, repl: str='', *args, **kwargs):
         """
         Initialization method.
 
@@ -17,16 +19,17 @@ class CleanEmailMapper(Mapper):
         :param kwargs: extra args
         """
         super().__init__(*args, **kwargs)
-        if pattern is None:
-            self.pattern = r'[A-Za-z0-9.\-+_]+@[a-z0-9.\-+_]+\.[a-z]+'
-        else:
-            self.pattern = pattern
 
+        self.pattern = pattern
+        if pattern is not None and len(pattern) > 0:
+            if (pattern.startswith("r'") and pattern.endswith("'") 
+                    or  pattern.startswith('r"') and pattern.endswith('"')):
+                self.pattern = pattern[2:-1]
         self.repl = repl
 
     def process(self, sample):
 
-        if not re.search(self.pattern, sample[self.text_key], flags=re.DOTALL):
+        if self.pattern is None:
             return sample
 
         sample[self.text_key] = re.sub(pattern=self.pattern,

--- a/data_juicer/ops/mapper/replace_content_mapper.py
+++ b/data_juicer/ops/mapper/replace_content_mapper.py
@@ -20,7 +20,7 @@ class ReplaceContentMapper(Mapper):
         """
         super().__init__(*args, **kwargs)
         self.pattern = pattern
-        if pattern is not None and len(pattern) > 0:
+        if pattern is not None and len(pattern) > 2:
             if (pattern.startswith("r'") and pattern.endswith("'")
                     or pattern.startswith('r"') and pattern.endswith('"')):
                 self.pattern = pattern[2:-1]

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -10,7 +10,7 @@ The operators in Data-Juicer are categorized into 5 types.
 | Type                              | Number | Description                                     |
 |-----------------------------------|:------:|-------------------------------------------------|
 | [ Formatter ]( #formatter )       |   7    | Discovers, loads, and canonicalizes source data |
-| [ Mapper ]( #mapper )             |   21   | Edits and transforms samples                    |
+| [ Mapper ]( #mapper )             |   22   | Edits and transforms samples                    |
 | [ Filter ]( #filter )             |   24   | Filters out low-quality samples                 |
 | [ Deduplicator ]( #deduplicator ) |   4    | Detects and removes duplicate samples           |
 | [ Selector ]( #selector )         |   2    | Selects top samples based on ranking            |
@@ -66,6 +66,7 @@ All the specific operators are listed below, each featured with several capabili
 | remove_specific_chars_mapper                        | General            | en, zh | Removes any user-specified characters or substrings                                                            |
 | remove_table_text_mapper                            | General, Financial | en     | Detects and removes possible table contents (:warning: relies on regular expression matching and thus fragile) |
 | remove_words_with_incorrect_<br />substrings_mapper | General            | en, zh | Removes words containing specified substrings                                                                  |
+| replace_content_mapper | General            | en, zh | Replace all content in the text that matches a specific regular expression pattern with a designated replacement string.                                                                 |
 | sentence_split_mapper                               | General            | en     | Splits and reorganizes sentences according to semantics                                                        |
 | whitespace_normalization_mapper                     | General            | en, zh | Normalizes various Unicode whitespaces to the normal ASCII space (U+0020)                                      |
 

--- a/docs/Operators_ZH.md
+++ b/docs/Operators_ZH.md
@@ -9,7 +9,7 @@ Data-Juicer 中的算子分为以下 5 种类型。
 | 类型                                 | 数量 | 描述            |
 |------------------------------------|:--:|---------------|
 | [ Formatter ]( #formatter )        |  7 | 发现、加载、规范化原始数据 |
-| [ Mapper ]( #mapper )              | 21 | 对数据样本进行编辑和转换  |
+| [ Mapper ]( #mapper )              | 22 | 对数据样本进行编辑和转换  |
 | [ Filter ]( #filter )              | 24 | 过滤低质量样本       |
 | [ Deduplicator ]( #deduplicator )  |  4 | 识别、删除重复样本     |
 | [ Selector ]( #selector )          |  2 | 基于排序选取高质量样本   |
@@ -64,6 +64,7 @@ Data-Juicer 中的算子分为以下 5 种类型。
 | remove_specific_chars_mapper                        | General               | en, zh    | 删除任何用户指定的字符或子字符串                                       |
 | remove_table_text_mapper                            | General, Financial    | en        | 检测并删除可能的表格内容（:warning: 依赖正则表达式匹配，因此很脆弱）                |
 | remove_words_with_incorrect_<br />substrings_mapper | General               | en, zh    | 删除包含指定子字符串的单词                                          |
+| replace_content_mapper                              | General            | en, zh | 使用一个指定的替换字符串替换文本中满足特定正则表达式模版的所有内容             |
 | sentence_split_mapper                               | General               | en        | 根据语义拆分和重组句子                                            |
 | whitespace_normalization_mapper                     | General               | en, zh    | 将各种 Unicode 空白标准化为常规 ASCII 空格 (U+0020)                 |
 

--- a/tests/ops/mapper/test_clean_email_mapper.py
+++ b/tests/ops/mapper/test_clean_email_mapper.py
@@ -5,12 +5,9 @@ from data_juicer.ops.mapper.clean_email_mapper import CleanEmailMapper
 
 class CleanEmailMapperTest(unittest.TestCase):
 
-    def setUp(self):
-        self.op = CleanEmailMapper()
-
-    def _run_clean_email(self, samples):
+    def _run_clean_email(self, op, samples):
         for sample in samples:
-            result = self.op.process(sample)
+            result = op.process(sample)
             self.assertEqual(result['text'], result['target'])
 
     def test_clean_email(self):
@@ -28,8 +25,26 @@ class CleanEmailMapperTest(unittest.TestCase):
             'text': '👊23da44sh12@46hqb12chd.ckdhnfes.comd.dasd.asd.dc',
             'target': '👊'
         }]
-        self._run_clean_email(samples)
+        op = CleanEmailMapper()
+        self._run_clean_email(op, samples)
 
+    def test_replace_email(self):
 
+        samples = [{
+            'text': 'happy day euqdh@cjqi.com',
+            'target': 'happy day <EMAIL>'
+        }, {
+            'text': '请问你是谁dasoidhao@1264fg.45om',
+            'target': '请问你是谁dasoidhao@1264fg.45om'
+        }, {
+            'text': 'ftp://examplema-nièrdash@hqbchd.ckdhnfes.cds',
+            'target': 'ftp://examplema-niè<EMAIL>'
+        }, {
+            'text': '👊23da44sh12@46hqb12chd.ckdhnfes.comd.dasd.asd.dc',
+            'target': '👊<EMAIL>'
+        }]
+        op = CleanEmailMapper(repl='<EMAIL>')
+        self._run_clean_email(op, samples)
+        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ops/mapper/test_clean_ip_mapper.py
+++ b/tests/ops/mapper/test_clean_ip_mapper.py
@@ -5,12 +5,9 @@ from data_juicer.ops.mapper.clean_ip_mapper import CleanIpMapper
 
 class CleanIpMapperTest(unittest.TestCase):
 
-    def setUp(self):
-        self.op = CleanIpMapper()
-
-    def _run_clean_ip(self, samples):
+    def _run_clean_ip(self, op, samples):
         for sample in samples:
-            result = self.op.process(sample)
+            result = op.process(sample)
             self.assertEqual(result['text'], result['target'])
 
     def test_ipv4(self):
@@ -28,7 +25,8 @@ class CleanIpMapperTest(unittest.TestCase):
             'text': 'ft174.1421.237.246my',
             'target': 'ft174.1421.237.246my'
         }]
-        self._run_clean_ip(samples)
+        op = CleanIpMapper()
+        self._run_clean_ip(op, samples)
 
     def test_ipv6(self):
 
@@ -45,8 +43,25 @@ class CleanIpMapperTest(unittest.TestCase):
             'text': 'ft1926:43a1:fcb5:ees06:ae63:a2a4:c656:d014my',
             'target': 'ft1926:43a1:fcb5:ees06:ae63:a2a4:c656:d014my'
         }]
-        self._run_clean_ip(samples)
+        op = CleanIpMapper()
+        self._run_clean_ip(op, samples)
 
+    def test_replace_ipv4(self):
 
+        samples = [{
+            'text': 'test of ip 234.128.124.123',
+            'target': 'test of ip <IP>'
+        }, {
+            'text': '34.0.124.123',
+            'target': '<IP>'
+        }, {
+            'text': 'ftp://example.com/188.46.244.216my-page.html',
+            'target': 'ftp://example.com/<IP>my-page.html'
+        }, {
+            'text': 'ft174.1421.237.246my',
+            'target': 'ft174.1421.237.246my'
+        }]
+        op = CleanIpMapper(repl='<IP>')
+        self._run_clean_ip(op, samples)
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ops/mapper/test_clean_links_mapper.py
+++ b/tests/ops/mapper/test_clean_links_mapper.py
@@ -8,9 +8,9 @@ class CleanLinksMapperTest(unittest.TestCase):
     def setUp(self):
         self.op = CleanLinksMapper()
 
-    def _run_clean_links(self, samples):
+    def _run_clean_links(self, op, samples):
         for sample in samples:
-            result = self.op.process(sample)
+            result = op.process(sample)
             self.assertEqual(result['text'], result['target'])
 
     def test_lower_ftp_links_text(self):
@@ -28,7 +28,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': 'ftp://example.com',
             'target': ''
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_upper_ftp_links_text(self):
 
@@ -45,7 +46,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': 'FTP://EXAMPLE.COM',
             'target': ''
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_lower_https_links_text(self):
 
@@ -61,7 +63,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': 'https://example.com',
             'target': ''
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_upper_https_links_text(self):
 
@@ -77,7 +80,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': 'HTTPS://EXAMPLE.COM',
             'target': ''
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_mixed_https_links_text(self):
 
@@ -93,7 +97,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': '这是个测试,https://example.com',
             'target': '这是个测试,'
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_lower_http_links_text(self):
 
@@ -109,7 +114,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': 'https://example.com',
             'target': ''
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_upper_http_links_text(self):
 
@@ -129,7 +135,8 @@ class CleanLinksMapperTest(unittest.TestCase):
                 'target': ''
             },
         ]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_mixed_http_links_text(self):
 
@@ -145,7 +152,8 @@ class CleanLinksMapperTest(unittest.TestCase):
             'text': '这是个测试,https://example.com',
             'target': '这是个测试,'
         }]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_email_text(self):
 
@@ -159,7 +167,8 @@ class CleanLinksMapperTest(unittest.TestCase):
                 'target': '这是一个测试, sample@example',
             },
         ]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_fake_links_text(self):
 
@@ -183,7 +192,8 @@ class CleanLinksMapperTest(unittest.TestCase):
                 'target': 'This is a test,'
             },
         ]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
     def test_no_link_text(self):
 
@@ -201,8 +211,27 @@ class CleanLinksMapperTest(unittest.TestCase):
                 'target': '，。、„”“«»１」「《》´∶：？！（）；–—．～’…━〈〉【】％►',
             },
         ]
-        self._run_clean_links(samples)
+        op = CleanLinksMapper()
+        self._run_clean_links(op, samples)
 
+    def test_replace_links_text(self):
+
+        samples = [{
+            'text': 'ftp://user:password@ftp.example.com:21/',
+            'target': '<LINKS>'
+        }, {
+            'text': 'This is a sample for test',
+            'target': 'This is a sample for test',
+        }, {
+            'text': 'abcd://ef is a sample for test',
+            'target': '<LINKS> is a sample for test',
+        }, {
+                'text':
+                'HTTP://example.com/my-page.html?param1=value1&param2=value2',
+                'target': '<LINKS>'
+            },]
+        op = CleanLinksMapper(repl='<LINKS>')
+        self._run_clean_links(op, samples)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ops/mapper/test_replace_content_mapper.py
+++ b/tests/ops/mapper/test_replace_content_mapper.py
@@ -1,0 +1,61 @@
+import unittest
+
+from data_juicer.ops.mapper.replace_content_mapper import \
+    ReplaceContentMapper
+
+
+class ReplaceContentMapperTest(unittest.TestCase):
+
+    def _run_helper(self,op, samples):
+        for sample in samples:
+            result = op.process(sample)
+            self.assertEqual(result['text'], result['target'])
+
+    def test_special_char_pattern_text(self):
+
+        samples = [
+            {
+                'text': '这是一个干净的文本。Including Chinese and English.',
+                'target': '这是一个干净的文本。Including Chinese and English.',
+            },
+            {
+                'text': '◆●■►▼▲▴∆▻▷❖♡□',
+                'target': '◆<SPEC>►▼▲▴∆▻▷❖♡□',
+            },
+            {
+                'text': '多个●■►▼这样的特殊字符可以►▼▲▴∆吗？',
+                'target': '多个<SPEC>►▼这样的特殊字符可以►▼▲▴∆吗？',
+            },
+            {
+                'text': '未指定的●■☛₨➩►▼▲特殊字符会☻▷❖被删掉吗？？',
+                'target': '未指定的<SPEC>☛₨➩►▼▲特殊字符会☻▷❖被删掉吗？？',
+            },
+        ]
+        op = ReplaceContentMapper(pattern='●■', repl='<SPEC>')
+        self._run_helper(op, samples)
+
+
+    def test_raw_digit_pattern_text(self):
+
+        samples = [
+            {
+                'text': '这是一个123。Including 456 and English.',
+                'target': '这是一个<DIGIT>。Including <DIGIT> and English.',
+            },
+        ]
+        op = ReplaceContentMapper(pattern=r'\d+(?:,\d+)*', repl='<DIGIT>')
+        self._run_helper(op, samples)
+    
+    def test_regular_digit_pattern_text(self):
+
+        samples = [
+            {
+                'text': '这是一个123。Including 456 and English.',
+                'target': '这是一个<DIGIT>。Including <DIGIT> and English.',
+            },
+        ]
+        op = ReplaceContentMapper(pattern='\\d+(?:,\\d+)*', repl='<DIGIT>')
+        self._run_helper(op, samples)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. Add  `replace content mapper`op to replace all content in text that matches a specific regular expression pattern with a designated replacement string.
2. Release some mapper initialization parameters, such as `pattern` and `repl`