### PR TITLE
Enhance/several minor opts

### DIFF
--- a/data_juicer/ops/filter/language_id_score_filter.py
+++ b/data_juicer/ops/filter/language_id_score_filter.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple, Union
+
 from jsonargparse.typing import ClosedUnitInterval
 from loguru import logger
 
@@ -19,23 +21,31 @@ class LanguageIDScoreFilter(Filter):
     larger than a specific min value."""
 
     def __init__(self,
-                 lang: str = '',
+                 lang: Union[str, List[str], Tuple[str]] = '',
                  min_score: ClosedUnitInterval = 0.8,
                  *args,
                  **kwargs):
         """
         Initialization method.
 
-        :param lang: Samples in which language to keep.
+        :param lang: Samples in which languages to keep.
         :param min_score: The min language identification confidence
             scores of samples to keep.
         :param args: extra args
         :param kwargs: extra args
         """
         super().__init__(*args, **kwargs)
-        self.lang = lang
+        if not lang:
+            # lang is [], '' or None
+            self.lang = None
+        elif isinstance(lang, str):
+            # lang is a single language string
+            self.lang = [lang]
+        else:
+            # lang is a list of multiple languages
+            self.lang = lang
         self.min_score = min_score
-        self.model_key = prepare_model(lang=lang, model_type='fasttext')
+        self.model_key = prepare_model(model_type='fasttext')
 
     def compute_stats(self, sample):
         # check if it's computed already
@@ -45,7 +55,6 @@ class LanguageIDScoreFilter(Filter):
 
         text = sample[self.text_key].lower().replace('\n', ' ')
         ft_model = get_model(self.model_key,
-                             lang=self.lang,
                              model_type='fasttext')
         if ft_model is None:
             err_msg = 'Model not loaded. Please retry later.'
@@ -62,7 +71,7 @@ class LanguageIDScoreFilter(Filter):
 
     def process(self, sample):
         if self.lang:
-            return sample[Fields.stats][StatsKeys.lang] == self.lang \
+            return sample[Fields.stats][StatsKeys.lang] in self.lang \
                    and sample[Fields.stats][StatsKeys.lang_score] >= \
                    self.min_score
         else:

--- a/tests/ops/filter/test_language_id_score_filter.py
+++ b/tests/ops/filter/test_language_id_score_filter.py
@@ -109,6 +109,46 @@ class LanguageIDScoreFilterTest(unittest.TestCase):
         op = LanguageIDScoreFilter(lang='', min_score=0.8)
         self._run_language_id_score_filter(dataset, tgt_list, op)
 
+    def test_multi_language_case(self):
+
+        ds_list = [{
+            'text': 'a=1\nb\nc=1+2+3+5\nd=6'
+        }, {
+            'text': '我出生于2023年12月15日'
+        }, {
+            'text': '他的英文名字叫Harry Potter'
+        }, {
+            'text':
+            "Today is Sund Sund Sund Sunda and it's a happy day!\nYou know"
+        }, {
+            'text': 'a v s e e f g a qkc'
+        }, {
+            'text': '，。、„”“«»１」「《》´∶：？！（）；–—．～’…━〈〉【】％►'
+        }, {
+            'text': 'Do you need a cup of coffee?'
+        }, {
+            'text': 'emoji表情测试下😊，😸31231\n'
+        }, {
+            'text': '这是一个测试'
+        }]
+        tgt_list = [{
+            'text': '我出生于2023年12月15日'
+        }, {
+            'text': '他的英文名字叫Harry Potter'
+        }, {
+            'text':
+            "Today is Sund Sund Sund Sunda and it's a happy day!\nYou know"
+        }, {
+            'text': '，。、„”“«»１」「《》´∶：？！（）；–—．～’…━〈〉【】％►'
+        }, {
+            'text': 'Do you need a cup of coffee?'
+        }, {
+            'text': '这是一个测试'
+        }]
+        dataset = Dataset.from_list(ds_list)
+        op = LanguageIDScoreFilter(lang=['en', 'zh'], min_score=0.8)
+        self._run_language_id_score_filter(dataset, tgt_list, op)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- language_id_score_filter supports keeping samples for multiple languages
- np checking to avoid starting too many subprocesses
- modify downloaded and extracted cache dirs that depend on HF_DATASETS_CACHE when it's updated