### PR TITLE
Fix `predict.py` stuck at help page

### DIFF
--- a/tools/quality_classifier/predict.py
+++ b/tools/quality_classifier/predict.py
@@ -121,14 +121,12 @@ def predict_score(dataset_path,
     # export prediction result to specific path
     export_result(pred, result_path)
 
-    # generate overall statistics on doc scores
-    overall = pred.select('doc_score').toPandas().describe(include='all')
     if overall_stats:
+        # generate overall statistics on doc scores
+        overall = pred.select('doc_score').toPandas().describe(include='all')
         # export to result report file
         overall.to_csv(os.path.join(result_path, 'overall.csv'))
         overall.to_markdown(os.path.join(result_path, 'overall.md'))
-
-    return overall
 
 
 if __name__ == '__main__':

--- a/tools/quality_classifier/predict.py
+++ b/tools/quality_classifier/predict.py
@@ -91,7 +91,8 @@ def predict_score(dataset_path,
     :param overall_stats: whether to output an overall stats report on
         predicted document scores. It's False in default
     :return:
-        average quality score of the document
+        None if overall_stats is False
+        average quality score of the document if overall_stats is True
     """
     # set default tokenizers for default models
     if model == 'chinese':
@@ -127,6 +128,7 @@ def predict_score(dataset_path,
         # export to result report file
         overall.to_csv(os.path.join(result_path, 'overall.csv'))
         overall.to_markdown(os.path.join(result_path, 'overall.md'))
+        return overall
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In quality classifier, `predict.py` will stuck at a help page after all procecss done. I remove the last return, it works fine.

![image](https://github.com/alibaba/data-juicer/assets/11705038/9b858d4e-3f4b-499e-b625-b3cce192ae66)

