### PR TITLE
Refine _cuda_device_count logic

### DIFF
--- a/data_juicer/__init__.py
+++ b/data_juicer/__init__.py
@@ -15,7 +15,7 @@ def _cuda_device_count():
 
         cuda_visible_devices = os.getenv('CUDA_VISIBLE_DEVICES')
 
-        if cuda_visible_devices:
+        if cuda_visible_devices is not None:
             visible_devices = cuda_visible_devices.split(',')
             visible_devices = [int(dev.strip()) for dev in visible_devices]
             num_visible_devices = sum(1 for dev in visible_devices

--- a/data_juicer/__init__.py
+++ b/data_juicer/__init__.py
@@ -6,24 +6,28 @@ import subprocess
 import multiprocess as mp
 from loguru import logger
 
+from data_juicer.utils.availability_utils import _is_package_available
+
 
 def _cuda_device_count():
+    _torch_available = _is_package_available('torch')
+
+    if _torch_available:
+        import torch
+        return torch.cuda.device_count()
+
     try:
         nvidia_smi_output = subprocess.check_output(['nvidia-smi', '-L'],
                                                     text=True)
         all_devices = nvidia_smi_output.strip().split('\n')
 
         cuda_visible_devices = os.getenv('CUDA_VISIBLE_DEVICES')
-
         if cuda_visible_devices is not None:
-            visible_devices = cuda_visible_devices.split(',')
-            visible_devices = [int(dev.strip()) for dev in visible_devices]
-            num_visible_devices = sum(1 for dev in visible_devices
-                                      if 0 <= dev < len(all_devices))
-        else:
-            num_visible_devices = len(all_devices)
+            logger.warning(
+                'CUDA_VISIBLE_DEVICES is ignored when torch is unavailable. '
+                'All detected GPUs will be used.')
 
-        return num_visible_devices
+        return len(all_devices)
     except Exception:
         # nvidia-smi not found or other error
         return 0

--- a/data_juicer/utils/availability_utils.py
+++ b/data_juicer/utils/availability_utils.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.metadata
+import importlib.util
 from typing import Tuple, Union
 
 from loguru import logger

--- a/data_juicer/utils/availability_utils.py
+++ b/data_juicer/utils/availability_utils.py
@@ -1,3 +1,6 @@
+import importlib.util
+from typing import Tuple, Union
+
 from loguru import logger
 
 UNAVAILABLE_OPERATORS = {}
@@ -94,3 +97,23 @@ class AvailabilityChecking:
 
         # return True to suppress the exception
         return True
+
+
+def _is_package_available(
+        pkg_name: str,
+        return_version: bool = False) -> Union[Tuple[bool, str], bool]:
+    # Check we're not importing a "pkg_name" directory somewhere
+    # but the actual library by trying to grab the version
+    package_exists = importlib.util.find_spec(pkg_name) is not None
+    package_version = 'N/A'
+    if package_exists:
+        try:
+            package_version = importlib.metadata.version(pkg_name)
+            package_exists = True
+        except importlib.metadata.PackageNotFoundError:
+            package_exists = False
+        logger.debug(f'Detected {pkg_name} version {package_version}')
+    if return_version:
+        return package_exists, package_version
+    else:
+        return package_exists

--- a/data_juicer/utils/availability_utils.py
+++ b/data_juicer/utils/availability_utils.py
@@ -1,4 +1,4 @@
-import importlib.util
+import importlib
 from typing import Tuple, Union
 
 from loguru import logger


### PR DESCRIPTION
* When `torch` is installed, we can utilize `torch.cuda.device_count()` to respect `CUDA_VISIBLE_DEVICES`. 
* Otherwise, it is non-trivial and prone to errors to manually parse `CUDA_VISIBLE_DEVICES`, so just ignore it for now.