### PR TITLE
fix nested dir bug

### DIFF
--- a/data_juicer/ops/mapper/audio_ffmpeg_wrapped_mapper.py
+++ b/data_juicer/ops/mapper/audio_ffmpeg_wrapped_mapper.py
@@ -56,9 +56,9 @@ class AudioFFmpegWrappedMapper(Mapper):
             return sample
 
         loaded_audio_keys = sample[self.audio_key]
-        proceessed = {}
+        processed = {}
         for audio_key in loaded_audio_keys:
-            if audio_key in proceessed:
+            if audio_key in processed:
                 continue
 
             output_key = transfer_filename(audio_key, OP_NAME,
@@ -69,7 +69,7 @@ class AudioFFmpegWrappedMapper(Mapper):
                 stream = stream.global_args(*self.global_args)
             stream.run(capture_stderr=self.capture_stderr,
                        overwrite_output=self.overwrite_output)
-            proceessed[audio_key] = output_key
+            processed[audio_key] = output_key
 
-        sample[self.audio_key] = [proceessed[key] for key in loaded_audio_keys]
+        sample[self.audio_key] = [processed[key] for key in loaded_audio_keys]
         return sample

--- a/data_juicer/ops/mapper/video_ffmpeg_wrapped_mapper.py
+++ b/data_juicer/ops/mapper/video_ffmpeg_wrapped_mapper.py
@@ -56,9 +56,9 @@ class VideoFFmpegWrappedMapper(Mapper):
             return sample
 
         loaded_video_keys = sample[self.video_key]
-        proceessed = {}
+        processed = {}
         for video_key in loaded_video_keys:
-            if video_key in proceessed:
+            if video_key in processed:
                 continue
 
             output_key = transfer_filename(video_key, OP_NAME,
@@ -69,7 +69,7 @@ class VideoFFmpegWrappedMapper(Mapper):
                 stream = stream.global_args(*self.global_args)
             stream.run(capture_stderr=self.capture_stderr,
                        overwrite_output=self.overwrite_output)
-            proceessed[video_key] = output_key
+            processed[video_key] = output_key
 
-        sample[self.video_key] = [proceessed[key] for key in loaded_video_keys]
+        sample[self.video_key] = [processed[key] for key in loaded_video_keys]
         return sample

--- a/data_juicer/ops/mapper/video_split_by_duration_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_duration_mapper.py
@@ -62,21 +62,19 @@ class VideoSplitByDurationMapper(Mapper):
         timestamps = np.arange(0, video_duration, self.split_duration).tolist()
         count = 0
         split_video_keys = []
+        unique_video_key = transfer_filename(video_key, OP_NAME,
+                                             **self._init_parameters)
         for i in range(1, len(timestamps)):
-            split_video_key = transfer_filename(video_key, OP_NAME,
-                                                **self._init_parameters)
-            suffix = '_split-by-duration-' + str(count)
-            split_video_key = add_suffix_to_filename(split_video_key, suffix)
+            split_video_key = add_suffix_to_filename(unique_video_key,
+                                                     f'_{count}')
             if cut_video_by_seconds(container, split_video_key,
                                     timestamps[i - 1], timestamps[i]):
                 split_video_keys.append(split_video_key)
                 count += 1
 
         if video_duration - timestamps[-1] >= self.min_last_split_duration:
-            split_video_key = transfer_filename(video_key, OP_NAME,
-                                                **self._init_parameters)
-            suffix = '_split-by-duration-' + str(count)
-            split_video_key = add_suffix_to_filename(split_video_key, suffix)
+            split_video_key = add_suffix_to_filename(unique_video_key,
+                                                     f'_{count}')
 
             if cut_video_by_seconds(container, split_video_key,
                                     timestamps[-1]):

--- a/data_juicer/ops/mapper/video_split_by_key_frame_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_key_frame_mapper.py
@@ -49,20 +49,17 @@ class VideoSplitByKeyFrameMapper(Mapper):
 
         count = 0
         split_video_keys = []
+        unique_video_key = transfer_filename(video_key, OP_NAME,
+                                             **self._init_parameters)
         for i in range(1, len(timestamps)):
-            split_video_key = transfer_filename(video_key, OP_NAME,
-                                                **self._init_parameters)
-            suffix = '_split-by-key-frame-' + str(count)
-            split_video_key = add_suffix_to_filename(split_video_key, suffix)
+            split_video_key = add_suffix_to_filename(unique_video_key,
+                                                     f'_{count}')
             if cut_video_by_seconds(container, split_video_key,
                                     timestamps[i - 1], timestamps[i]):
                 split_video_keys.append(split_video_key)
                 count += 1
 
-        split_video_key = transfer_filename(video_key, OP_NAME,
-                                            **self._init_parameters)
-        suffix = '_split-by-key-frame-' + str(count)
-        split_video_key = add_suffix_to_filename(split_video_key, suffix)
+        split_video_key = add_suffix_to_filename(unique_video_key, f'_{count}')
         if cut_video_by_seconds(container, split_video_key, timestamps[-1]):
             split_video_keys.append(split_video_key)
         return split_video_keys

--- a/data_juicer/ops/mapper/video_split_by_scene_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_scene_mapper.py
@@ -100,7 +100,7 @@ class VideoSplitBySceneMapper(Mapper):
             redirected_video_key = transfer_filename(video_key, OP_NAME,
                                                      **self._init_parameters)
             output_template = add_suffix_to_filename(redirected_video_key,
-                                                     '_Scene-$SCENE_NUMBER')
+                                                     '_$SCENE_NUMBER')
 
             # detect scenes
             detector = self.detector_class(self.threshold, self.min_scene_len,

--- a/data_juicer/utils/constant.py
+++ b/data_juicer/utils/constant.py
@@ -19,6 +19,9 @@ class Fields(object):
     video_frame_tags = DEFAULT_PREFIX + 'video_frame_tags__'
     video_audio_tags = DEFAULT_PREFIX + 'video_audio_tags__'
 
+    # the name of diretory to store the produced multimodal datas
+    multimodal_data_output_dir = DEFAULT_PREFIX + 'produced_datas__'
+
 
 class StatsKeysMeta(type):
     """

--- a/data_juicer/utils/constant.py
+++ b/data_juicer/utils/constant.py
@@ -19,8 +19,8 @@ class Fields(object):
     video_frame_tags = DEFAULT_PREFIX + 'video_frame_tags__'
     video_audio_tags = DEFAULT_PREFIX + 'video_audio_tags__'
 
-    # the name of diretory to store the produced multimodal datas
-    multimodal_data_output_dir = DEFAULT_PREFIX + 'produced_datas__'
+    # the name of diretory to store the produced multimodal data
+    multimodal_data_output_dir = DEFAULT_PREFIX + 'produced_data__'
 
 
 class StatsKeysMeta(type):

--- a/data_juicer/utils/file_utils.py
+++ b/data_juicer/utils/file_utils.py
@@ -8,7 +8,7 @@ from typing import List, Tuple, Union
 
 from datasets.utils.extract import ZstdExtractor as Extractor
 
-from data_juicer.utils.constant import DEFAULT_PREFIX
+from data_juicer.utils.constant import DEFAULT_PREFIX, Fields
 
 
 def find_files_with_suffix(
@@ -132,24 +132,27 @@ def transfer_filename(original_filepath: Union[str, Path], op_name,
         original_filepath to another unique file path. E.g.
 
             1. abc.jpg -->
-                {op_name}/abc__dj_hash_#{hash_val}#.jpg
+                __dj__produced_datas__/{op_name}/
+                abc__dj_hash_#{hash_val}#.jpg
             2. ./abc.jpg -->
-                ./{op_name}/abc__dj_hash_#{hash_val}#.jpg
+                ./__dj__produced_datas__/{op_name}/
+                abc__dj_hash_#{hash_val}#.jpg
             3. /path/to/abc.jpg -->
-                /path/to/{op_name}/abc__dj_hash_#{hash_val}#.jpg
-            4. /path/to/{op_name}/abc.jpg -->
-                /path/to/{op_name}/abc__dj_hash_#{hash_val}#.jpg
-            5. /path/to/{op_name}/abc__dj_hash_#{hash_val1}#.jpg -->
-                /path/to/{op_name}/abc__dj_hash_#{hash_val2}#.jpg
+                /path/to/__dj__produced_datas__/{op_name}/
+                abc__dj_hash_#{hash_val}#.jpg
+            4. /path/to/__dj__produced_datas__/{op_name}/
+                abc__dj_hash_#{hash_val1}#.jpg -->
+                /path/to/__dj__produced_datas__/{op_name}/
+                abc__dj_hash_#{hash_val2}#.jpg
 
     """
     # produce the directory
     original_dir = os.path.dirname(original_filepath)
-    parent_dir = os.path.basename(original_dir)
-    if parent_dir == op_name:
-        new_dir = original_dir
-    else:
-        new_dir = os.path.join(original_dir, f'{op_name}')
+    dir_token = f'/{Fields.multimodal_data_output_dir}/'
+    if dir_token in original_dir:
+        original_dir = original_dir.split(dir_token)[0]
+    new_dir = os.path.join(original_dir,
+                           f'{Fields.multimodal_data_output_dir}/{op_name}')
     create_directory_if_not_exists(new_dir)
 
     # produce the unique hash code

--- a/data_juicer/utils/file_utils.py
+++ b/data_juicer/utils/file_utils.py
@@ -132,17 +132,17 @@ def transfer_filename(original_filepath: Union[str, Path], op_name,
         original_filepath to another unique file path. E.g.
 
             1. abc.jpg -->
-                __dj__produced_datas__/{op_name}/
+                __dj__produced_data__/{op_name}/
                 abc__dj_hash_#{hash_val}#.jpg
             2. ./abc.jpg -->
-                ./__dj__produced_datas__/{op_name}/
+                ./__dj__produced_data__/{op_name}/
                 abc__dj_hash_#{hash_val}#.jpg
             3. /path/to/abc.jpg -->
-                /path/to/__dj__produced_datas__/{op_name}/
+                /path/to/__dj__produced_data__/{op_name}/
                 abc__dj_hash_#{hash_val}#.jpg
-            4. /path/to/__dj__produced_datas__/{op_name}/
+            4. /path/to/__dj__produced_data__/{op_name}/
                 abc__dj_hash_#{hash_val1}#.jpg -->
-                /path/to/__dj__produced_datas__/{op_name}/
+                /path/to/__dj__produced_data__/{op_name}/
                 abc__dj_hash_#{hash_val2}#.jpg
 
     """

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -147,9 +147,10 @@ class StatsKeys(object):
             # ... (same as above)
     ```
 
-    - In a mapper operator, to avoid process conflicts and data coverage, we offer an interface to make a saving path for produced extra datas. The format of the saving path is `{ORIGINAL_DATAPATH}/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`, where the `HASH_VALUE` is hashed from the init parameters of the operator, the related parameters in each sample, the process ID, and the timestamp. For convenience, we can call `self.remove_extra_parameters(locals())` at the beginning of the initiation to get the init parameters. At the same time, we can call `self.add_parameters` to add related parameters with the produced extra datas from each sample. Take the operator which enhances the images with diffusion models as example:
+    - In a mapper operator, to avoid process conflicts and data coverage, we offer an interface to make a saving path for produced extra datas. The format of the saving path is `{ORIGINAL_DATAPATH}/__dj__produced_datas__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`, where the `HASH_VALUE` is hashed from the init parameters of the operator, the related parameters in each sample, the process ID, and the timestamp. For convenience, we can call `self.remove_extra_parameters(locals())` at the beginning of the initiation to get the init parameters. At the same time, we can call `self.add_parameters` to add related parameters with the produced extra datas from each sample. Take the operator which enhances the images with diffusion models as example:
     ```python
-    # ... (import some library)
+    from data_juicer.utils.file_utils import transfer_filename
+    # ... (import some other libraries)
     OP_NAME = 'image_diffusion_mapper'
     @OPERATORS.register_module(OP_NAME)
     @LOADED_IMAGES.register_module(OP_NAME)
@@ -172,7 +173,8 @@ class StatsKeys(object):
     ```
     For the mapper to produce multi extra datas base on one origin data, we can add suffix at the saving path. Take the operator which splits videos according to their key frames as example:
     ```python
-    # ... (import some library)
+    from data_juicer.utils.file_utils import add_suffix_to_filename, transfer_filename
+    # ... (import some other libraries)
     OP_NAME = 'video_split_by_key_frame_mapper'
     @OPERATORS.register_module(OP_NAME)
     @LOADED_VIDEOS.register_module(OP_NAME)

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -147,7 +147,7 @@ class StatsKeys(object):
             # ... (same as above)
     ```
 
-    - In a mapper operator, to avoid process conflicts and data coverage, we offer an interface to make a saving path for produced extra datas. The format of the saving path is `{ORIGINAL_DATAPATH}/__dj__produced_datas__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`, where the `HASH_VALUE` is hashed from the init parameters of the operator, the related parameters in each sample, the process ID, and the timestamp. For convenience, we can call `self.remove_extra_parameters(locals())` at the beginning of the initiation to get the init parameters. At the same time, we can call `self.add_parameters` to add related parameters with the produced extra datas from each sample. Take the operator which enhances the images with diffusion models as example:
+    - In a mapper operator, to avoid process conflicts and data coverage, we offer an interface to make a saving path for produced extra datas. The format of the saving path is `{ORIGINAL_DATAPATH}/__dj__produced_data__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`, where the `HASH_VALUE` is hashed from the init parameters of the operator, the related parameters in each sample, the process ID, and the timestamp. For convenience, we can call `self.remove_extra_parameters(locals())` at the beginning of the initiation to get the init parameters. At the same time, we can call `self.add_parameters` to add related parameters with the produced extra datas from each sample. Take the operator which enhances the images with diffusion models as example:
     ```python
     from data_juicer.utils.file_utils import transfer_filename
     # ... (import some other libraries)
@@ -190,8 +190,7 @@ class StatsKeys(object):
             # ... (some codes)
             split_video_path = transfer_filename(
                         original_video_path, OP_NAME, **self._init_parameters)
-            suffix = '_split-by-key-frame-' + str(count)
-            split_video_path = add_suffix_to_filename(split_video_path, suffix)
+            split_video_path = add_suffix_to_filename(split_video_path,  f'_{count}')
             # ... (some codes)
     ```
 

--- a/docs/DeveloperGuide_ZH.md
+++ b/docs/DeveloperGuide_ZH.md
@@ -142,7 +142,7 @@ class StatsKeys(object):
             # ... (same as above)
     ```
 
-    - 在mapper算子中，我们提供了产生额外数据的存储路径生成接口，避免出现进程冲突和数据覆盖的情况。生成的存储路径格式为`{ORIGINAL_DATAPATH}/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`，其中`HASH_VALUE`是算子初始化参数、每个样本中相关参数、进程ID和时间戳的哈希值。为了方便，可以在OP类初始化开头调用`self.remove_extra_parameters(locals())`获取算子初始化参数，同时可以调用`self.add_parameters`添加每个样本与生成额外数据相关的参数。例如，利用diffusion模型对图像进行增强的算子：
+    - 在mapper算子中，我们提供了产生额外数据的存储路径生成接口，避免出现进程冲突和数据覆盖的情况。生成的存储路径格式为`{ORIGINAL_DATAPATH}/__dj__produced_datas__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`，其中`HASH_VALUE`是算子初始化参数、每个样本中相关参数、进程ID和时间戳的哈希值。为了方便，可以在OP类初始化开头调用`self.remove_extra_parameters(locals())`获取算子初始化参数，同时可以调用`self.add_parameters`添加每个样本与生成额外数据相关的参数。例如，利用diffusion模型对图像进行增强的算子：
     ```python
     # ... (import some library)
     OP_NAME = 'image_diffusion_mapper'

--- a/docs/DeveloperGuide_ZH.md
+++ b/docs/DeveloperGuide_ZH.md
@@ -142,7 +142,7 @@ class StatsKeys(object):
             # ... (same as above)
     ```
 
-    - 在mapper算子中，我们提供了产生额外数据的存储路径生成接口，避免出现进程冲突和数据覆盖的情况。生成的存储路径格式为`{ORIGINAL_DATAPATH}/__dj__produced_datas__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`，其中`HASH_VALUE`是算子初始化参数、每个样本中相关参数、进程ID和时间戳的哈希值。为了方便，可以在OP类初始化开头调用`self.remove_extra_parameters(locals())`获取算子初始化参数，同时可以调用`self.add_parameters`添加每个样本与生成额外数据相关的参数。例如，利用diffusion模型对图像进行增强的算子：
+    - 在mapper算子中，我们提供了产生额外数据的存储路径生成接口，避免出现进程冲突和数据覆盖的情况。生成的存储路径格式为`{ORIGINAL_DATAPATH}/__dj__produced_data__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`，其中`HASH_VALUE`是算子初始化参数、每个样本中相关参数、进程ID和时间戳的哈希值。为了方便，可以在OP类初始化开头调用`self.remove_extra_parameters(locals())`获取算子初始化参数，同时可以调用`self.add_parameters`添加每个样本与生成额外数据相关的参数。例如，利用diffusion模型对图像进行增强的算子：
     ```python
     # ... (import some library)
     OP_NAME = 'image_diffusion_mapper'
@@ -183,8 +183,7 @@ class StatsKeys(object):
             # ... (some codes)
             split_video_path = transfer_filename(
                         original_video_path, OP_NAME, **self._init_parameters)
-            suffix = '_split-by-key-frame-' + str(count)
-            split_video_path = add_suffix_to_filename(split_video_path, suffix)
+            split_video_path = add_suffix_to_filename(split_video_path, f'_{count}')
             # ... (some codes)
     ```
 

--- a/tests/ops/mapper/test_video_resize_resolution_mapper.py
+++ b/tests/ops/mapper/test_video_resize_resolution_mapper.py
@@ -26,7 +26,6 @@ class VideoResizeResolutionMapperTest(DataJuicerTestCaseBase):
         for sample in dataset.to_list():
             cur_list = []
             for value in sample['videos']:
-                print(value)
                 probe = ffmpeg.probe(value)
                 video_stream = next((stream for stream in probe['streams']
                                      if stream['codec_type'] == 'video'), None)


### PR DESCRIPTION
1. fix the bug that the produced multimodal datas would be store in nested dirs in different ops.
2. change the path format from `{ORIGINAL_DATAPATH}/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}` to `{ORIGINAL_DATAPATH}/__dj__produced_datas__/{OP_NAME}/{ORIGINAL_FILENAME}__dj_hash_#{HASH_VALUE}#.{EXT}`.